### PR TITLE
Add leaping to accent characters and words in identifiers

### DIFF
--- a/lua/leap-by-word.lua
+++ b/lua/leap-by-word.lua
@@ -15,7 +15,46 @@ local function get_input()
   end
 end
 
+-- patterns and functions for testing if a character should be considered a target
+local matches = {
+  upper = [=[\v[[:upper:]]\C]=],
+  lower = [=[\v[[:lower:]]\C]=],
+  digit = [=[\v[[:digit:]]\C]=],
+  word  = [=[\v[[:upper:][:lower:][:digit:]]\C]=],
+}
+local function test(char, match)
+  if char == nil then return false -- vim.fn.match returns false for nil char, but not if pattern contains `[:lower:]`
+  else return vim.fn.match(char, match) == 0 end
+end
+
+local function test_split_identifiers(chars, cur_i)
+  local cur_char = chars[cur_i]
+
+  local is_match = false
+
+  if test(cur_char, matches.upper) then
+    local prev_char = chars[cur_i - 1]
+    if not test(prev_char, matches.upper) then is_match = true
+    else
+      local next_char = chars[cur_i + 1]
+      is_match = test(next_char, matches.word) and not test(next_char, matches.upper)
+    end
+  elseif test(cur_char, matches.digit) then
+    is_match = not test(chars[cur_i - 1], matches.digit)
+  elseif test(cur_char, matches.lower) then
+    is_match = not test(chars[cur_i - 1], matches.word) or test(chars[cur_i - 1], matches.digit)
+  else
+    local prev_char = chars[cur_i - 1]
+    is_match = prev_char ~= cur_char -- matching only first character in ==, [[ and ]]
+  end
+
+  return is_match
+end
+
 local function get_targets(winid, char, direction)
+  -- Case sensitive version: "\\v[[="..char.."=]]\\C"
+  local match_regex = "\\v[[="..char.."=]]\\c"
+
   local wininfo = vim.fn.getwininfo(winid)[1]
   local lnum = wininfo.topline
   local botline = wininfo.botline
@@ -48,39 +87,22 @@ local function get_targets(winid, char, direction)
       lnum = fold_end + 1
     else
       local line = vim.fn.getline(lnum)
+      local chars = vim.fn.split(line, '\\zs')
+
       -- this works fine with columns that are outside of the screen to the left
       -- it also works fine with columns that are outside of the screen to the right
       -- BUT leap does not display labels for targets that are beyond the right border,
       -- although it does display labels for targets that are beyond the left border
-      local current_line = line
-      print(" current_line:" .. current_line)
-      local col = first_col
-      -- while col <= last_col do
-      while true do -- search beyond last column
-        -- shift current_line with whitespace to match easily with pattern even the first character
-        current_line = " " .. current_line
-        local lower_char = string.lower(char)
-        local upper_char = string.upper(char)
-        -- Case sensitive pattern:
-        -- local pattern = "%W" .. char .. "[%w_-]*[%W]*"
-        -- Ignore case pattern:
-        local pattern = "%W[" .. lower_char .. upper_char .. "][%w_-]*[%W]*"
-        local start_pos, end_pos = string.find(current_line, pattern)
-        if start_pos == nil then
-          break
+      local col = 1
+      for i, cur in ipairs(chars) do -- search beyond last column
+        -- v  first_col <= col and col <= last_col and
+        if test(cur, match_regex) and test_split_identifiers(chars, i) then
+          table.insert(targets, { pos = { lnum, col } })
         end
-        -- go back to normal values
-        current_line = string.sub(current_line, 2, -1)
-        start_pos = start_pos - 1
-        end_pos = end_pos - 1
-        -- values are as if current_line was not right shifted with whitespace
-        local match_col = col + start_pos
-        -- increase end_pos by 1 because otherwise we are including last character from prev match
-        current_line = string.sub(current_line, end_pos + 1)
-        print("Match, line:" .. lnum .. " col:" .. match_col)
-        table.insert(targets, { pos = { lnum, match_col } })
-        col = col + end_pos
+        col = col + string.len(cur)
       end
+      assert(string.len(line) == col - 1)
+
       lnum = lnum + 1
     end
   end
@@ -99,7 +121,7 @@ local function get_targets(winid, char, direction)
 end
 
 local function leap(opts, leap_override_opts)
-  local opts = opts or {}
+  opts = opts or {}
   local direction = opts.direction or "both"
   print("Search word with letter:")
   local char = get_input()


### PR DESCRIPTION
As it's currently implemented, the algorithm for finding matching characters does not consider words in identifiers like `currentLine`, `CurrentLine` and `current_line` as words, allowing jumps only to the letter 'c', but not 'l'. Current algorithm also doesn't consider accented characters as 'word characters', not jumping to them if a word begins with them (like 'École'), and also allowing to jump to the next character after them (e.g. on 's' in 'résumé'). The algorithm also probably doesn't work with underscores correctly, allowing jumps to last 't' in `size_t`, but not in `time_t`. The algorithm also doesn't consider multibyte unicode characters. It also doesn't allow jumping to '<' in `#include<file>` directives.

This pull request adds `test_function` option that determines which function is used for determining which characters should become targets. Default function (named `test_regular`) mimics original behavior (it works with unicode, handles underscores and non-words like '<' and '=', and is otherwise the same as far as I've tested). There is also another function `test_split_identifiers` which allows jumping to parts of identifiers. Both functions make use of [character classes](https://vimhelp.org/pattern.txt.html#%5B%3Alower%3A%5D) that, from my test, support unicode characters. Input character matches are checked with [equivalence class](https://vimhelp.org/pattern.txt.html#pattern-overview:~:text=using%20isupper()%0A%09%09%09%09%09%09%09/%5B%5B%3D-,%5B%3D%3D%5D,-%2D%20An%20equivalence) of that character.
 