### PR TITLE
Improve performance with large number of labels

### DIFF
--- a/lua/leap-by-word.lua
+++ b/lua/leap-by-word.lua
@@ -84,18 +84,19 @@ local function get_targets(winid, char, direction)
       lnum = lnum + 1
     end
   end
+  if #targets == 0 then return end
   -- Sort them by vertical screen distance from cursor.
   local cur_screen_row = vim.fn.screenpos(winid, cursor_line, 1)["row"]
-  local function screen_rows_from_cur(t)
-    local t_screen_row = vim.fn.screenpos(winid, t.pos[1], t.pos[2])["row"]
-    return math.abs(cur_screen_row - t_screen_row)
+  for _, t in ipairs(targets) do
+    local pos = vim.fn.screenpos(winid, t.pos[1], t.pos[2])
+    if pos.row > 0 and pos.col > 0 then
+      t.screen_line_diff = math.abs(cur_screen_row - pos.row)
+    else
+      t.screen_line_diff = math.huge
+    end
   end
-  table.sort(targets, function(t1, t2)
-    return screen_rows_from_cur(t1) < screen_rows_from_cur(t2)
-  end)
-  if #targets >= 1 then
-    return targets
-  end
+  table.sort(targets, function(t1, t2) return t1.screen_line_diff < t2.screen_line_diff end)
+  return targets
 end
 
 local function leap(opts, leap_override_opts)


### PR DESCRIPTION
Measuring the time it takes from getting user input to calling Leap's leap, I noticed that quite a lot of time was spent sorting the labels by screen distance from the cursor. As it turned out `vim.fn.screenpos` is very slow and calling it twice for each comparison significantly increases the total time if there is a lot of labels. I added a loop that precomputes the distance to the cursor before sorting on it instead of recomputing it for each comparison. 
I measured the difference on leap-by-word.lua, resized so that the entire file fits inside the window, searching by space. Original sorting takes 1000ms on average, and this version takes around 25ms on my laptop.